### PR TITLE
issue-3-reduce: Added 3 versions of .reduce

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -59,6 +59,8 @@ endfunction()
 
 add_google_test(test_sequenceEqual.cpp)
 
+add_google_test(test_reduce.cpp)
+
 add_named_test("heap.enumerable" test_heap_enumerable.cpp)
 expect("heap.enumerable" "\n0 1 2 3 4 5 6 \n")
 expect("heap.enumerable" "\n0.000000 1.000000 2.000000 3.000000 4.000000 5.000000 6.000000 \n")

--- a/test/test_heap_enumerable.cpp
+++ b/test/test_heap_enumerable.cpp
@@ -54,7 +54,6 @@ int main(int argc, char* argv[])
 		s.m_enum.forEach(printFloat); printf("\n");
 
 		auto&& ss = fromFunction(array);
-		int asd;
 		ss.m_enum.forEach(printFloat); printf("\n");
 	}
 	catch (std::exception& e)

--- a/test/test_reduce.cpp
+++ b/test/test_reduce.cpp
@@ -1,0 +1,100 @@
+#include <stdio.h>
+
+#include <enumerable/enumerable.h>
+#include <vector>
+#include <string>
+
+#include <gtest/gtest.h>
+
+TEST(Reduce, SeedFromParameter)
+{
+	int array[5] = { 1,2,3,4,5 };
+	
+	EXPECT_EQ(15, Enumerable(array).reduce([](int i, int sum) { return i + sum; },  0));
+	EXPECT_EQ(25, Enumerable(array).reduce([](int i, int sum) { return i + sum; }, 10));
+}
+
+TEST(Reduce, SeedFromLambdaDefaultParameter)
+{
+	int array[5] = { 1,2,3,4,5 };
+
+	EXPECT_EQ(15, Enumerable(array).reduce([](int i, int sum = 0) { return i + sum; }));
+	EXPECT_EQ(25, Enumerable(array).reduce([](int i, int sum = 0) { return i + sum; }, 10));
+}
+
+TEST(Reduce, NoSeed)
+{
+	int array[5] = { 1,2,3,4,5 };
+
+	EXPECT_EQ(15, Enumerable(array).reduce([](int i, int sum) { return i + sum; }));
+}
+
+TEST(Reduce, StringReduceTestLambda)
+{
+	std::vector<std::string> stringVector = {
+		"The", "quick", "brown", "fox", "jumps", "over", "the", "lazy", "dog"
+	};
+	
+	// Using normal seed
+	auto reducedWhitespace = Enumerable(stringVector).reduce([](auto str, std::string sum) { return sum + " " + str; }, "");
+	EXPECT_EQ(std::string(" The quick brown fox jumps over the lazy dog"), reducedWhitespace);
+
+	// Using seed from lambda default
+	auto reducedComma = Enumerable(stringVector).reduce([](std::string str, std::string sum="") { return sum + "," + str; });
+	EXPECT_EQ(std::string(",The,quick,brown,fox,jumps,over,the,lazy,dog"), reducedComma);
+
+	// First element is seed
+	auto reducedWhitespaceNoSeed = Enumerable(stringVector).reduce([](auto str, std::string sum) { return sum + " " + str; });
+	EXPECT_EQ(std::string("The quick brown fox jumps over the lazy dog"), reducedWhitespaceNoSeed);
+}
+
+std::string ReduceStringWhitespace(std::string str, std::string sum)
+{
+	return sum + " " + str;
+}
+std::string ReduceStringComma(std::string str, std::string sum = "")
+{
+	return sum + "," + str;
+}
+
+TEST(Reduce, StringReduceTestFixedFunc)
+{
+	std::vector<std::string> stringVector = {
+		"The", "quick", "brown", "fox", "jumps", "over", "the", "lazy", "dog"
+	};
+	
+	// Using normal seed
+	auto reducedWhitespace = Enumerable(stringVector).reduce(ReduceStringWhitespace, "");
+	EXPECT_EQ(std::string(" The quick brown fox jumps over the lazy dog"), reducedWhitespace);
+
+	// Seed is used from first element, even though the function has a default argument.
+	auto reducedComma = Enumerable(stringVector).reduce(ReduceStringComma);
+	EXPECT_EQ(std::string("The,quick,brown,fox,jumps,over,the,lazy,dog"), reducedComma);
+
+	// First element is seed
+	auto reducedWhitespaceNoSeed = Enumerable(stringVector).reduce(ReduceStringWhitespace);
+	EXPECT_EQ(std::string("The quick brown fox jumps over the lazy dog"), reducedWhitespaceNoSeed);
+}
+
+TEST(Reduce, EmptySequenceExceptionTest)
+{
+	std::vector<std::string> stringVector = {
+	};
+	
+	// Using normal seed
+	ASSERT_THROW(
+		Enumerable(stringVector).reduce([](auto str, std::string sum) { return sum + " " + str; }, "")
+		, std::out_of_range);
+
+	// Using seed from lambda default
+	ASSERT_THROW(
+		Enumerable(stringVector).reduce([](std::string str, std::string sum="") { return sum + "," + str; })
+		, std::out_of_range);
+
+	// First element is seed
+	ASSERT_THROW(
+		Enumerable(stringVector).reduce([](auto str, std::string sum) { return sum + " " + str; })
+		, std::out_of_range);
+
+}
+


### PR DESCRIPTION
1. One which takes a seed parameter
2. One which uses the first element as seed
3. Functor only: One which can use the default argument of the reduce functor as seed.
   For non-functors 2) will be used.
