### PR TITLE
issue #12: Implemented a fallthrough Enumerable(...)

### DIFF
--- a/include/enumerable/containerEnumerable.h
+++ b/include/enumerable/containerEnumerable.h
@@ -47,13 +47,15 @@ private:
 // Works with simple containers like std::vector, std::list, etc.
 // Basically anything that implements ::iterator, .begin() and .end()
 template <typename T, template <typename, typename> class Container, typename ContainerAllocator>
-ContainerEnumerable<T, Container<T, ContainerAllocator>> Enumerable(Container<T, ContainerAllocator>& container)
+auto Enumerable(Container<T, ContainerAllocator>& container,
+	typename Container<T, ContainerAllocator>::iterator* = nullptr)
 {
 	return ContainerEnumerable<T, Container<T, ContainerAllocator>>(container);
 }
 
 template <typename T, template <typename, typename, typename> class Container, typename ContainerCompare, typename ContainerAllocator>
-ContainerEnumerable<T, Container<T, ContainerCompare, ContainerAllocator>> Enumerable(Container<T, ContainerCompare, ContainerAllocator>& container)
+auto Enumerable(Container<T, ContainerCompare, ContainerAllocator>& container,
+	typename Container<T, ContainerCompare, ContainerAllocator>::iterator* = nullptr)
 {
 	return ContainerEnumerable<T, Container<T, ContainerCompare, ContainerAllocator>>(container);
 }

--- a/include/enumerable/enumerableTemplate.h
+++ b/include/enumerable/enumerableTemplate.h
@@ -683,7 +683,12 @@ struct EnumerableBase : virtual public IEnumerable<T>
 		}
 		return ret;		
 	}
-	
-	
+		
 };
 
+template <typename T, typename Derived>
+auto Enumerable(const EnumerableBase<T, Derived>& toCopy) 
+-> Derived
+{
+	return static_cast<const Derived&>(toCopy);
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -72,3 +72,4 @@ add_google_test(test_tocontainer.cpp)
 add_google_test(test_foreach_lambda.cpp)
 
 add_google_test(test_take.cpp)
+add_google_test(test_enumerable.cpp)

--- a/test/test_enumerable.cpp
+++ b/test/test_enumerable.cpp
@@ -1,0 +1,13 @@
+#include <stdio.h>
+
+#include <gtest/gtest.h>
+
+#include <enumerable/enumerable.h>
+
+TEST(Enumerable, Fallthrough)
+{
+	int array[3] = { 1,2,3 };
+	auto src = Enumerable(array);
+	auto cpy = Enumerable(src);
+	EXPECT_TRUE(src.sequenceEqual(cpy));	
+}


### PR DESCRIPTION
It accepts things of the type `const EnumerableBase<T,Derived>`
 and returns `Derived`, a copy of the argument.

Also implemented enable_if on the container-version of Enumerable

fixes #12
