### PR TITLE
issue-16: Made it possible to wrap functions with Enumerable()

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Some core concepts in the library is _deffered execution_, _dependency inversion
 * [Methods](#methods)
    * [Sequence transforming functions](#sequence-transforming-functions)
    * [Sequence reducing functions](#sequence-reducing-functions)
+   * [Enumerable-overloads](#enumerable-overloads)
 * [More details](#more-details)
 	
 
@@ -196,6 +197,19 @@ Method | Description
 `reduce(Reducer(value, accumulator))` | Reduces the sequence. Throws `std::out_of_range` on empty sequences. The first element is used as value for `accumulator` on first iteration. [Source](include/enumerable/enumerableTemplate.h#L124-L140), [Examples/Tests](test/test_reduce.cpp)
 --- | ---
 `forEach(sink)` | Calls `sink` once for every element in the sequence.
+
+### Enumerable overloads
+
+These are the overloads of Enumerable
+
+Signature | Description
+------ | -----------
+`Enumerable<T,size>(T(&src)[size])` | Used on static sized arrays of type `T`. `T` and `size` are derived from the argument. [Source](include/enumerable/arrayEnumerable.h#L52-L57)
+`Enumerable<T>(T* t, int size)` | Used on pointer type / dynamically sized arrays of type `T`. `T` is derived from the argument. `size` specifies the length of the array, counted in contiguous `T`s. [Source](include/enumerable/arrayEnumerable.h#L59-L64)
+`Enumerable<Container<T, Alloc>>(Container& container)` | Valid for most `std` container types. In fact, anything that has .begin(), .end() and ::iterator works. The generated object contains a reference to the source container. [Source](include/enumerable/containerEnumerable.h#L46-L54)
+`Enumerable<Container<T, Compare, Alloc>>(Container& container)` | Valid for most `std` container types. In fact, anything that has .begin(), .end() and ::iterator works. The generated object contains a reference to the source container. [Source](include/enumerable/containerEnumerable.h#L56-L61)
+`Enumerable(Generator)` | Calls the supplied `Generator` on `moveNext()` to generate values for `value()`. Thus represents an infinite sequence of values. `Generator` should return a value, and be callable with no arguments. [Source](include/enumerable/enumerableTemplate.h#L710-L724) [Examples/Tests](test/test_enumerable.cpp#L15-L23)
+`Enumerable(const EnumerableBase<T,Derived>&)` | Returns a copy of the supplied enumerable. [Source](include/enumerable/enumerableTemplate.h#L703-L708) [Examples/Tests](test/test_enumerable.cpp#L7-L13)
 
 ## More details
 

--- a/clang.bat
+++ b/clang.bat
@@ -2,5 +2,5 @@ set CC=clang
 set CXX=clang++
 mkdir build-clang
 cd build-clang
-cmake .. -G "Unix Makefiles" && cmake --build . && ctest .. -V
+cmake .. -G "Unix Makefiles" && cmake --build . -- -j4 && ctest .. -V
 cd ..

--- a/gcc.bat
+++ b/gcc.bat
@@ -2,5 +2,5 @@ set CC=gcc
 set CXX=g++
 mkdir build-gcc
 cd build-gcc
-cmake .. -G "Unix Makefiles" && cmake --build . && ctest ..
+cmake .. -G "Unix Makefiles" && cmake --build . -- -j4 && ctest ..
 cd ..

--- a/include/enumerable/enumerableTemplate.h
+++ b/include/enumerable/enumerableTemplate.h
@@ -706,3 +706,20 @@ auto Enumerable(const EnumerableBase<T, Derived>& toCopy)
 {
 	return static_cast<const Derived&>(toCopy);
 }
+
+template <typename Generator, typename Element = typename std::result_of<Generator()>::type>
+auto Enumerable(Generator&& generator)
+{
+	struct GeneratorEnumerable : public EnumerableBase<Element, GeneratorEnumerable>
+	{
+		GeneratorEnumerable(Generator&& gen) : generator(gen) {}
+		Generator generator;
+		Element m_value;
+		
+		virtual Element value() override { return m_value; };
+		virtual bool moveNext() override { m_value = generator(); return true; }
+	};
+	
+	return GeneratorEnumerable{generator};
+}
+

--- a/test/test_enumerable.cpp
+++ b/test/test_enumerable.cpp
@@ -11,3 +11,14 @@ TEST(Enumerable, Fallthrough)
 	auto cpy = Enumerable(src);
 	EXPECT_TRUE(src.sequenceEqual(cpy));	
 }
+
+TEST(Enumerable, FunctionGenerator)
+{
+	int idx = 0;
+	auto generator = [&]{
+		return ++idx;
+	};
+	auto seq = Enumerable(generator);
+	EXPECT_EQ(1234, seq.take(1234).last());	
+}
+

--- a/vc.bat
+++ b/vc.bat
@@ -2,5 +2,5 @@ set CC=
 set CXX=
 mkdir build-vc
 cd build-vc
-call cmake -G "Visual Studio 14 2015" .. && cmake --build . && ctest .. -V
+call cmake -G "Visual Studio 14 2015" .. && cmake --build . -- /m && ctest .. -V
 cd ..


### PR DESCRIPTION
Wrapping a `T generator(void)`-like function with Enumerable cretes
an infinite sequence object (`Type=T`), where elements are created
by calling the `generator` function.

Also updated the readme with information about various Enumerable-overloads.

fixes #16 
